### PR TITLE
전시 pin 설정 API 연동, 전시 목록 정렬 및 카테고리별 조회 추가

### DIFF
--- a/__generate__/artwork/api.ts
+++ b/__generate__/artwork/api.ts
@@ -128,6 +128,12 @@ export interface ArtworkThumbnailDtoPage {
     'pageable'?: PageableObject;
     /**
      * 
+     * @type {boolean}
+     * @memberof ArtworkThumbnailDtoPage
+     */
+    'last'?: boolean;
+    /**
+     * 
      * @type {number}
      * @memberof ArtworkThumbnailDtoPage
      */
@@ -138,12 +144,6 @@ export interface ArtworkThumbnailDtoPage {
      * @memberof ArtworkThumbnailDtoPage
      */
     'totalElements'?: number;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof ArtworkThumbnailDtoPage
-     */
-    'last'?: boolean;
     /**
      * 
      * @type {number}
@@ -164,16 +164,16 @@ export interface ArtworkThumbnailDtoPage {
     'sort'?: Sort;
     /**
      * 
-     * @type {number}
-     * @memberof ArtworkThumbnailDtoPage
-     */
-    'numberOfElements'?: number;
-    /**
-     * 
      * @type {boolean}
      * @memberof ArtworkThumbnailDtoPage
      */
     'first'?: boolean;
+    /**
+     * 
+     * @type {number}
+     * @memberof ArtworkThumbnailDtoPage
+     */
+    'numberOfElements'?: number;
     /**
      * 
      * @type {boolean}

--- a/__generate__/category/api.ts
+++ b/__generate__/category/api.ts
@@ -45,6 +45,12 @@ export interface CategoryDto {
      * @memberof CategoryDto
      */
     'sequence'?: number;
+    /**
+     * 카테고리 별 전시수
+     * @type {number}
+     * @memberof CategoryDto
+     */
+    'postNum'?: number;
 }
 /**
  * 카테고리 생성 Request

--- a/__generate__/post/api.ts
+++ b/__generate__/post/api.ts
@@ -280,6 +280,12 @@ export interface PostDetailInfo {
      * @memberof PostDetailInfo
      */
     'published'?: boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof PostDetailInfo
+     */
+    'pinned'?: boolean;
 }
 /**
  * 
@@ -301,6 +307,12 @@ export interface PostDetailInfoPage {
     'pageable'?: PageableObject;
     /**
      * 
+     * @type {boolean}
+     * @memberof PostDetailInfoPage
+     */
+    'last'?: boolean;
+    /**
+     * 
      * @type {number}
      * @memberof PostDetailInfoPage
      */
@@ -311,12 +323,6 @@ export interface PostDetailInfoPage {
      * @memberof PostDetailInfoPage
      */
     'totalElements'?: number;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof PostDetailInfoPage
-     */
-    'last'?: boolean;
     /**
      * 
      * @type {number}
@@ -337,16 +343,16 @@ export interface PostDetailInfoPage {
     'sort'?: Sort;
     /**
      * 
-     * @type {number}
-     * @memberof PostDetailInfoPage
-     */
-    'numberOfElements'?: number;
-    /**
-     * 
      * @type {boolean}
      * @memberof PostDetailInfoPage
      */
     'first'?: boolean;
+    /**
+     * 
+     * @type {number}
+     * @memberof PostDetailInfoPage
+     */
+    'numberOfElements'?: number;
     /**
      * 
      * @type {boolean}
@@ -399,6 +405,12 @@ export interface PostInfoByCategoryDtoPage {
     'pageable'?: PageableObject;
     /**
      * 
+     * @type {boolean}
+     * @memberof PostInfoByCategoryDtoPage
+     */
+    'last'?: boolean;
+    /**
+     * 
      * @type {number}
      * @memberof PostInfoByCategoryDtoPage
      */
@@ -409,12 +421,6 @@ export interface PostInfoByCategoryDtoPage {
      * @memberof PostInfoByCategoryDtoPage
      */
     'totalElements'?: number;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof PostInfoByCategoryDtoPage
-     */
-    'last'?: boolean;
     /**
      * 
      * @type {number}
@@ -435,16 +441,16 @@ export interface PostInfoByCategoryDtoPage {
     'sort'?: Sort;
     /**
      * 
-     * @type {number}
-     * @memberof PostInfoByCategoryDtoPage
-     */
-    'numberOfElements'?: number;
-    /**
-     * 
      * @type {boolean}
      * @memberof PostInfoByCategoryDtoPage
      */
     'first'?: boolean;
+    /**
+     * 
+     * @type {number}
+     * @memberof PostInfoByCategoryDtoPage
+     */
+    'numberOfElements'?: number;
     /**
      * 
      * @type {boolean}
@@ -506,13 +512,13 @@ export interface Sort {
      * @type {boolean}
      * @memberof Sort
      */
-    'sorted'?: boolean;
+    'unsorted'?: boolean;
     /**
      * 
      * @type {boolean}
      * @memberof Sort
      */
-    'unsorted'?: boolean;
+    'sorted'?: boolean;
 }
 /**
  * 전시 수정 Request

--- a/apis/category.ts
+++ b/apis/category.ts
@@ -1,11 +1,7 @@
 import { axiosInstance } from "@/libs/axios";
 import { CategoryControllerApiFactory } from "@/__generate__/category";
 
-const factory = CategoryControllerApiFactory(
-  undefined,
-  undefined,
-  axiosInstance
-);
+const factory = CategoryControllerApiFactory(undefined, undefined, axiosInstance);
 
 export const getCategories = async () => {
   try {
@@ -14,17 +10,4 @@ export const getCategories = async () => {
   } catch (err) {
     return [];
   }
-};
-
-export const getMockCategories = () => {
-  return Promise.resolve([
-    { text: "전체 기록", active: false },
-    { text: "졸업전시", active: false },
-    { text: "졸업전시", active: false },
-    { text: "졸업전시", active: false },
-    { text: "졸업전시", active: false },
-    { text: "졸업전시", active: false },
-    { text: "졸업전시", active: false },
-    { text: "졸업전시", active: false },
-  ]);
 };

--- a/apis/exhibition.ts
+++ b/apis/exhibition.ts
@@ -2,21 +2,26 @@ import { Exhibition } from "@/interfaces/exhibition";
 import { axiosInstance } from "@/libs/axios";
 import { ExhibitControllerApiFactory } from "@/__generate__/post";
 
-const factory = ExhibitControllerApiFactory(
-  undefined,
-  undefined,
-  axiosInstance
-);
+const factory = ExhibitControllerApiFactory(undefined, undefined, axiosInstance);
 
 export const getPostPage = (id: number, pagable: { size: number; page: number }) => {
-  const { size, page } = pagable
+  const { size, page } = pagable;
   return factory.getPostPage(id, size, page);
 };
 
-export const getAllPostPage = async (pagable: { size: number; page: number }) => {
-  const { size, page } = pagable
+export const getAllPostPage = async ({
+  size = 100,
+  page = 0,
+  direction,
+  category,
+}: {
+  size?: number;
+  page?: number;
+  direction?: "ASC" | "DESC";
+  category?: number;
+}) => {
   try {
-    const response = await factory.getAllPostPage(size, page);
+    const response = await factory.getAllPostPage(size, page, direction, category);
     return response.data;
   } catch (err) {
     return null;

--- a/apis/exhibition.ts
+++ b/apis/exhibition.ts
@@ -22,8 +22,9 @@ export const getAllPostPage = async ({
   }
 };
 
-export const togglePinById = (id: string) => {
-  return Promise.resolve(true);
+export const togglePinById = async (id: number, category?: boolean, pinned?: boolean) => {
+  const response = await factory.updatePostPinType(id, category, pinned);
+  return response.data;
 };
 
 export const getPostInfoWithCategory = async (id: number) => {

--- a/apis/exhibition.ts
+++ b/apis/exhibition.ts
@@ -1,13 +1,7 @@
-import { Exhibition } from "@/interfaces/exhibition";
 import { axiosInstance } from "@/libs/axios";
 import { ExhibitControllerApiFactory } from "@/__generate__/post";
 
 const factory = ExhibitControllerApiFactory(undefined, undefined, axiosInstance);
-
-export const getPostPage = (id: number, pagable: { size: number; page: number }) => {
-  const { size, page } = pagable;
-  return factory.getPostPage(id, size, page);
-};
 
 export const getAllPostPage = async ({
   size = 100,
@@ -26,53 +20,6 @@ export const getAllPostPage = async ({
   } catch (err) {
     return null;
   }
-};
-
-export const getExhibitionList = (): Promise<Exhibition[]> => {
-  return Promise.resolve([
-    {
-      id: 123,
-      imageUrl: "https://picsum.photos/358",
-      title: "목조형가구학과 졸전",
-      date: "2022. 11. 08",
-    },
-    {
-      id: 1,
-      imageUrl: "https://picsum.photos/358",
-      title: "전시회명어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구",
-      date: "2022. 11. 08",
-    },
-    {
-      id: 2,
-      imageUrl: "https://picsum.photos/358",
-      title: "전시회명어쩌구저쩌구",
-      date: "2022. 11. 08",
-    },
-    {
-      id: 3,
-      imageUrl: "https://picsum.photos/358",
-      title: "전시회명어쩌구저쩌구",
-      date: "2022. 11. 08",
-    },
-    {
-      id: 4,
-      imageUrl: "https://picsum.photos/358",
-      title: "전시회명어쩌구저쩌구",
-      date: "2022. 11. 08",
-    },
-    {
-      id: 5,
-      imageUrl: "https://picsum.photos/358",
-      title: "전시회명어쩌구저쩌구",
-      date: "2022. 11. 08",
-    },
-    {
-      id: 6,
-      imageUrl: "https://picsum.photos/358",
-      title: "전시회명어쩌구저쩌구",
-      date: "2022. 11. 08",
-    },
-  ]);
 };
 
 export const togglePinById = (id: string) => {

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -6,14 +6,13 @@ import { ExhibitionCardList } from "@/components/pages/Home/ExhibitionCardList/E
 import { Select } from "@/components/ui/Select/Select";
 import { useSelectCategory } from "@/hooks/useSelectCategory";
 import { AppBar } from "@/components/pages/Home/AppBar/AppBar";
-import { getAllPostPage } from "@/apis/exhibition";
-import { getCategories } from "@/apis/category";
 import { PostFloatingButton } from "@/components/pages/Home/PostFloatingButton/PostFloatingButton";
 import { sendMessage } from "@/libs/message/message";
 import { PostDetailInfo } from "@/__generate__/post";
 import ExhibitionListEmpty from "@/components/ui/Empty/ExhibitionListEmpty/ExhibitionListEmpty";
 import * as S from "./page.styles";
-import { useTogglePinById } from "@/hooks/exhibition";
+import { useGetExhibitionList, useTogglePinById } from "@/hooks/exhibition";
+import { useGetCategoryList } from "@/hooks/category";
 
 export default function PageWrapper() {
   return (
@@ -24,20 +23,11 @@ export default function PageWrapper() {
 }
 
 function Page() {
-  const { data: categories } = useQuery({
-    queryKey: ["categories"],
-    queryFn: getCategories,
-  });
-
   const { selectedIndex, selectCategoryByIndex: handleSelectCategory } = useSelectCategory();
-
   const { selectedIndex: selectedFilter, selectCategoryByIndex: handleSelectFilter } = useSelectCategory();
-
-  const { data: allPostInfo = [] } = useQuery({
-    queryKey: ["getAllPostPage", { direction: selectedFilter, category: selectedIndex }],
-    queryFn: () => getAllPostPage({ direction: selectedFilter ? "ASC" : "DESC", category: selectedIndex || undefined }),
-    select: (data) => data?.content ?? [],
-  });
+  const { data: categories } = useGetCategoryList();
+  const { data: allPostInfo = [] } = useGetExhibitionList(selectedFilter ? "ASC" : "DESC", selectedIndex || undefined);
+  const { mutate } = useTogglePinById();
 
   const fixedExhibition = useMemo(() => {
     return allPostInfo.find((item) => item.pinned);
@@ -47,7 +37,6 @@ function Page() {
 
   const handleRegisterCategory = useCallback(() => {}, []);
 
-  const { mutate } = useTogglePinById();
   const handleTogglePin = async (e: React.MouseEvent, item: PostDetailInfo) => {
     mutate({ id: item.id, category: Boolean(selectedIndex), pinned: !(item.id === fixedExhibition?.id) });
   };

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -28,17 +28,13 @@ function Page() {
     queryFn: getCategories,
   });
 
-  const { selectedIndex, selectCategoryByIndex: handleSelectCategory } =
-    useSelectCategory();
+  const { selectedIndex, selectCategoryByIndex: handleSelectCategory } = useSelectCategory();
 
-  const {
-    selectedIndex: selectedFilter,
-    selectCategoryByIndex: handleSelectFilter,
-  } = useSelectCategory();
+  const { selectedIndex: selectedFilter, selectCategoryByIndex: handleSelectFilter } = useSelectCategory();
 
   const { data: allPostInfo } = useQuery({
-    queryKey: ["getAllPostPage"],
-    queryFn: () => getAllPostPage({ page: 0, size: 100 }),
+    queryKey: ["getAllPostPage", { direction: selectedFilter, category: selectedIndex }],
+    queryFn: () => getAllPostPage({ direction: selectedFilter ? "ASC" : "DESC", category: selectedIndex || undefined }),
   });
 
   const [pins, setPins] = useState<Record<string, boolean>>({});
@@ -52,23 +48,20 @@ function Page() {
     });
   }, [allPostInfo, pins]);
   const [fixedExhibition, ...restExhibition] = exhibitionListWithPin;
-  const isEmpty = exhibitionListWithPin.length === 0
+  const isEmpty = exhibitionListWithPin.length === 0;
 
   const handleRegisterCategory = useCallback(() => {}, []);
 
-  const handleTogglePin = useCallback(
-    async (e: React.MouseEvent, item: PostDetailInfo) => {
-      const id = String(item.id);
-      setPins((pins) => {
-        return {
-          ...pins,
-          [id]: !Boolean(pins[id]),
-        };
-      });
-      await togglePinById(id);
-    },
-    []
-  );
+  const handleTogglePin = useCallback(async (e: React.MouseEvent, item: PostDetailInfo) => {
+    const id = String(item.id);
+    setPins((pins) => {
+      return {
+        ...pins,
+        [id]: !Boolean(pins[id]),
+      };
+    });
+    await togglePinById(id);
+  }, []);
 
   const handleEditButton = useCallback((e: React.MouseEvent) => {
     sendMessage(["NAVIGATE_TO_EDIT"]);
@@ -79,7 +72,7 @@ function Page() {
       <AppBar />
       <S.CategoryListStyled
         activeIndex={selectedIndex}
-        items={categories ?? []}
+        items={categories ? [{ id: 0, name: "전체 기록" }, ...categories] : []}
         onSelected={handleSelectCategory}
         onRegister={handleRegisterCategory}
       />

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import React, { Suspense, useCallback, useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import React, { Suspense, useCallback, useMemo } from "react";
 import { ExhibitionCardList } from "@/components/pages/Home/ExhibitionCardList/ExhibitionCardList";
 import { Select } from "@/components/ui/Select/Select";
 import { useSelectCategory } from "@/hooks/useSelectCategory";
@@ -35,8 +34,6 @@ function Page() {
 
   const isEmpty = allPostInfo.length === 0;
 
-  const handleRegisterCategory = useCallback(() => {}, []);
-
   const handleTogglePin = async (e: React.MouseEvent, item: PostDetailInfo) => {
     mutate({ id: item.id, category: Boolean(selectedIndex), pinned: !(item.id === fixedExhibition?.id) });
   };
@@ -52,7 +49,6 @@ function Page() {
         activeIndex={selectedIndex}
         items={categories ? [{ id: 0, name: "전체 기록" }, ...categories] : []}
         onSelected={handleSelectCategory}
-        onRegister={handleRegisterCategory}
       />
       <S.Filter>
         <Select activeIndex={selectedFilter} onSelected={handleSelectFilter} />

--- a/components/pages/Home/CategoryList/CategoryList.tsx
+++ b/components/pages/Home/CategoryList/CategoryList.tsx
@@ -25,16 +25,9 @@ export const CategoryList = (props: Props) => {
 
   return (
     <S.Wrapper className={className}>
-      {items.map((item, index) => {
+      {items.map((item) => {
         const { id, name } = item;
-        return (
-          <Category
-            key={id}
-            active={activeIndex === index}
-            text={name}
-            onClick={handleSelectCategory(index)}
-          />
-        );
+        return <Category key={id} active={activeIndex === id} text={name} onClick={handleSelectCategory(id ?? 0)} />;
       })}
     </S.Wrapper>
   );

--- a/components/pages/Home/CategoryList/CategoryList.tsx
+++ b/components/pages/Home/CategoryList/CategoryList.tsx
@@ -8,11 +8,10 @@ interface Props {
   activeIndex?: number;
   items: CategoryDto[];
   onSelected: (index: number) => void;
-  onRegister: () => void;
 }
 
 export const CategoryList = (props: Props) => {
-  const { className, activeIndex, items = [], onSelected, onRegister } = props;
+  const { className, activeIndex, items = [], onSelected } = props;
 
   const handleSelectCategory = useCallback(
     (index: number) => {

--- a/components/pages/Home/ExhibitionCardList/ExhibitionCardList.styles.tsx
+++ b/components/pages/Home/ExhibitionCardList/ExhibitionCardList.styles.tsx
@@ -5,7 +5,6 @@ export const Wrapper = styled.div``;
 export const Content = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: center;
   flex-wrap: wrap;
   padding: 24px 16px;
   gap: 8px;

--- a/components/pages/Home/ExhibitionCardList/ExhibitionCardList.tsx
+++ b/components/pages/Home/ExhibitionCardList/ExhibitionCardList.tsx
@@ -5,7 +5,7 @@ import * as S from "./ExhibitionCardList.styles";
 import { PostDetailInfo } from "@/__generate__/post";
 
 interface Props {
-  fixedExhibition: PostDetailInfo;
+  fixedExhibition: PostDetailInfo | undefined;
   exhibitionList: Array<PostDetailInfo>;
   onTogglePin?: (e: React.MouseEvent, item: PostDetailInfo) => void;
 }
@@ -24,20 +24,14 @@ export const ExhibitionCardList = (props: Props) => {
 
   return (
     <S.Wrapper>
-      {fixedExhibition && (
-        <MainExhibitionCard
-          {...fixedExhibition}
-          onTogglePin={handleTogglePin(fixedExhibition)}
-        />
-      )}
+      {fixedExhibition && <MainExhibitionCard {...fixedExhibition} onTogglePin={handleTogglePin(fixedExhibition)} />}
       <S.Content>
-        {exhibitionList.map((exhibition) => (
-          <ExhibitionCard
-            key={exhibition.id}
-            {...exhibition}
-            onTogglePin={handleTogglePin(exhibition)}
-          />
-        ))}
+        {exhibitionList.map(
+          (exhibition) =>
+            !exhibition.pinned && (
+              <ExhibitionCard key={exhibition.id} {...exhibition} onTogglePin={handleTogglePin(exhibition)} />
+            )
+        )}
       </S.Content>
     </S.Wrapper>
   );

--- a/hooks/category.tsx
+++ b/hooks/category.tsx
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { getCategories } from "@/apis/category";
+
+export const useGetCategoryList = () => {
+  return useQuery({
+    queryKey: ["categories"],
+    queryFn: getCategories,
+  });
+};

--- a/hooks/exhibition.tsx
+++ b/hooks/exhibition.tsx
@@ -1,5 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { getPostInfoWithCategory, togglePinById } from "@/apis/exhibition";
+import { getAllPostPage, getPostInfoWithCategory, togglePinById } from "@/apis/exhibition";
+
+export const useGetExhibitionList = (direction: "ASC" | "DESC", category?: number) => {
+  return useQuery({
+    queryKey: ["getAllPostPage", { direction, category }],
+    queryFn: () => getAllPostPage({ direction, category }),
+    select: (data) => data?.content ?? [],
+  });
+};
 
 export const useGetPostInfo = (exhibitionId: number) => {
   return useQuery({

--- a/hooks/exhibition.tsx
+++ b/hooks/exhibition.tsx
@@ -1,9 +1,21 @@
-import { useQuery } from "@tanstack/react-query";
-import { getPostInfoWithCategory } from "@/apis/exhibition";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getPostInfoWithCategory, togglePinById } from "@/apis/exhibition";
 
 export const useGetPostInfo = (exhibitionId: number) => {
-    return useQuery({
+  return useQuery({
     queryKey: ["postInfo", exhibitionId],
     queryFn: () => getPostInfoWithCategory(exhibitionId),
-  })
-}
+  });
+};
+
+export const useTogglePinById = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, category, pinned }: { id: number; category?: boolean; pinned?: boolean }) =>
+      togglePinById(id, category, pinned),
+    onSuccess: () => {
+      queryClient.invalidateQueries(["getAllPostPage"]);
+    },
+  });
+};


### PR DESCRIPTION
## 관련 이슈

#issue

## 작업 내용⚒️
- 전시 pin 설정 및 해제 api 연동
- 전시 목록 조회 쿼리 파라미터 추가 (카테고리/정렬)
- 전체 기록 카테고리 추가

## 논의 사항👥

