### PR TITLE
ActionSheet 컴포넌트 설계 변경 및 작품 수정 액션시트 컴포넌트 분리

### DIFF
--- a/components/pages/ArtworkCardList/ArtworkCardList.tsx
+++ b/components/pages/ArtworkCardList/ArtworkCardList.tsx
@@ -65,24 +65,13 @@ const ArtworkCardList = ({ exhibitionId }: Props) => {
           </li>
         ))}
       </S.Wrapper>
-      <ActionSheet
-        isOpen={isOpenActionSheet}
-        actionList={[
-          {
-            actionName: "대표이미지로 선택",
-            onActionClick: handleArtworkPin,
-          },
-          {
-            actionName: "게시글 수정",
-            onActionClick: handleArtworkEdit,
-          },
-          {
-            actionName: "삭제",
-            onActionClick: artworkList?.length === 1 ? openAlertModal : handleArtworkDelete,
-          },
-        ]}
-        onClose={closeActionSheet}
-      />
+      <ActionSheet isOpen={isOpenActionSheet} onClose={closeActionSheet}>
+        <ActionSheet.Item onClick={handleArtworkPin}>대표 이미지로 선택</ActionSheet.Item>
+        <ActionSheet.Item onClick={handleArtworkEdit}>게시글 수정</ActionSheet.Item>
+        <ActionSheet.Item onClick={artworkList?.length === 1 ? openAlertModal : handleArtworkDelete}>
+          삭제
+        </ActionSheet.Item>
+      </ActionSheet>
       {isOpenAlertModal ? <ArtworkDeleteAlertModal onClose={closeAlertModal} onConfirm={handleArtworkDelete} /> : null}
     </>
   );

--- a/components/pages/ArtworkCardList/ArtworkCardList.tsx
+++ b/components/pages/ArtworkCardList/ArtworkCardList.tsx
@@ -17,10 +17,12 @@ const ArtworkCardList = ({ exhibitionId }: Props) => {
   const { isOpen, open, close } = useOverlay();
   const [selectedArtworkId, setSelectedArtworkId] = useState(-1);
 
-  const handleMoreBtnClick = (artworkId: number) => (e: React.MouseEvent) => {
-    e.preventDefault();
-    setSelectedArtworkId(artworkId);
-    open();
+  const handleMoreBtnClick = (artworkId: number) => {
+    return (e: React.MouseEvent) => {
+      e.preventDefault();
+      setSelectedArtworkId(artworkId);
+      open();
+    };
   };
 
   return (

--- a/components/pages/ArtworkCardList/ArtworkCardList.tsx
+++ b/components/pages/ArtworkCardList/ArtworkCardList.tsx
@@ -2,11 +2,9 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useGetArtworkList, useSetMainArtwork, useDeleteArtwork } from "@/hooks/artwork";
-import ActionSheet from "@/components/ui/ActionSheet/ActionSheet";
+import { useGetArtworkList } from "@/hooks/artwork";
+import { ArtworkEditActionSheet } from "@/components/pages/ArtworkCardList/ArtworkEditActionSheet";
 import ArtworkCard from "../ArtworkCard/ArtworkCard";
-import ArtworkDeleteAlertModal from "@/components/pages/ArtworkDeleteAlertModal/ArtworkDeleteAlertModal";
 import useOverlay from "@/hooks/useOverlay";
 import * as S from "./ArtworkCardList.styles";
 
@@ -15,65 +13,33 @@ interface Props {
 }
 
 const ArtworkCardList = ({ exhibitionId }: Props) => {
-  const router = useRouter();
   const { data: artworkList } = useGetArtworkList(exhibitionId);
-  const { mutate: setMainArtworkMutate } = useSetMainArtwork(exhibitionId);
-  const { mutate: deleteArtworkMutate } = useDeleteArtwork(exhibitionId);
-  const { isOpen: isOpenActionSheet, open: openActionSheet, close: closeActionSheet } = useOverlay();
-  const { isOpen: isOpenAlertModal, open: openAlertModal, close: closeAlertModal } = useOverlay();
+  const { isOpen, open, close } = useOverlay();
   const [selectedArtworkId, setSelectedArtworkId] = useState(-1);
 
   const handleMoreBtnClick = (artworkId: number) => (e: React.MouseEvent) => {
     e.preventDefault();
     setSelectedArtworkId(artworkId);
-    openActionSheet();
-  };
-
-  const handleArtworkPin = () => {
-    setMainArtworkMutate(selectedArtworkId, {
-      onSuccess: () => {
-        handleActionSheetClose();
-      },
-    });
-  };
-
-  const handleArtworkEdit = () => {
-    router.push(`/exhibition/${exhibitionId}/${selectedArtworkId}?edit=true`);
-  };
-
-  const handleArtworkDelete = () => {
-    deleteArtworkMutate(selectedArtworkId, {
-      onSuccess: () => {
-        handleActionSheetClose();
-      },
-    });
-  };
-
-  const handleActionSheetClose = () => {
-    setSelectedArtworkId(-1);
-    closeActionSheet();
+    open();
   };
 
   return (
-    <>
-      <S.Wrapper>
-        {artworkList?.map((artwork) => (
-          <li key={artwork.id}>
-            <Link href={`/exhibition/${exhibitionId}/${artwork.id}`}>
-              <ArtworkCard {...artwork} onMoreBtnClick={handleMoreBtnClick(artwork.id)} />
-            </Link>
-          </li>
-        ))}
-      </S.Wrapper>
-      <ActionSheet isOpen={isOpenActionSheet} onClose={closeActionSheet}>
-        <ActionSheet.Item onClick={handleArtworkPin}>대표 이미지로 선택</ActionSheet.Item>
-        <ActionSheet.Item onClick={handleArtworkEdit}>게시글 수정</ActionSheet.Item>
-        <ActionSheet.Item onClick={artworkList?.length === 1 ? openAlertModal : handleArtworkDelete}>
-          삭제
-        </ActionSheet.Item>
-      </ActionSheet>
-      {isOpenAlertModal ? <ArtworkDeleteAlertModal onClose={closeAlertModal} onConfirm={handleArtworkDelete} /> : null}
-    </>
+    <S.Wrapper>
+      {artworkList?.map((artwork) => (
+        <li key={artwork.id}>
+          <Link href={`/exhibition/${exhibitionId}/${artwork.id}`}>
+            <ArtworkCard {...artwork} onMoreBtnClick={handleMoreBtnClick(artwork.id)} />
+          </Link>
+        </li>
+      ))}
+      <ArtworkEditActionSheet
+        isOpen={isOpen}
+        onClose={close}
+        exhibitionId={exhibitionId}
+        artworkId={selectedArtworkId}
+        isLastArtwork={artworkList?.length === 1}
+      />
+    </S.Wrapper>
   );
 };
 

--- a/components/pages/ArtworkCardList/ArtworkEditActionSheet.tsx
+++ b/components/pages/ArtworkCardList/ArtworkEditActionSheet.tsx
@@ -1,0 +1,49 @@
+import { useRouter } from "next/navigation";
+import { useSetMainArtwork, useDeleteArtwork } from "@/hooks/artwork";
+import ActionSheet from "@/components/ui/ActionSheet/ActionSheet";
+import ArtworkDeleteAlertModal from "@/components/pages/ArtworkDeleteAlertModal/ArtworkDeleteAlertModal";
+import useOverlay from "@/hooks/useOverlay";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  exhibitionId: number;
+  artworkId: number;
+  isLastArtwork: boolean;
+};
+
+export const ArtworkEditActionSheet = ({ isOpen, onClose, exhibitionId, artworkId, isLastArtwork }: Props) => {
+  const router = useRouter();
+  const { mutate: setMainArtworkMutate } = useSetMainArtwork(exhibitionId);
+  const { mutate: deleteArtworkMutate } = useDeleteArtwork(exhibitionId);
+  const { isOpen: isOpenAlertModal, open: openAlertModal, close: closeAlertModal } = useOverlay();
+
+  const handleArtworkPin = () => {
+    setMainArtworkMutate(artworkId, {
+      onSuccess: () => {
+        onClose();
+      },
+    });
+  };
+
+  const handleArtworkEdit = () => {
+    router.push(`/exhibition/${exhibitionId}/${artworkId}?edit=true`);
+  };
+
+  const handleArtworkDelete = () => {
+    deleteArtworkMutate(artworkId, {
+      onSuccess: () => {
+        onClose();
+      },
+    });
+  };
+
+  return (
+    <ActionSheet isOpen={isOpen} onClose={onClose}>
+      <ActionSheet.Item onClick={handleArtworkPin}>대표 이미지로 선택</ActionSheet.Item>
+      <ActionSheet.Item onClick={handleArtworkEdit}>게시글 수정</ActionSheet.Item>
+      <ActionSheet.Item onClick={isLastArtwork ? openAlertModal : handleArtworkDelete}>삭제</ActionSheet.Item>
+      {isOpenAlertModal && <ArtworkDeleteAlertModal onClose={closeAlertModal} onConfirm={handleArtworkDelete} />}
+    </ActionSheet>
+  );
+};

--- a/components/ui/ActionSheet/ActionSheet.stories.tsx
+++ b/components/ui/ActionSheet/ActionSheet.stories.tsx
@@ -6,12 +6,13 @@ export default {
   component: ActionSheet,
 } as Meta;
 
-const Template: StoryFn<typeof ActionSheet> = (args) => <ActionSheet {...args} />;
-
-export const Primary = Template.bind({});
-Primary.args = {
-  actionList: [
-    { actionName: "게시글 수정", onActionClick: () => {} },
-    { actionName: "삭제", onActionClick: () => {} },
-  ],
+export const Default: StoryFn<typeof ActionSheet> = (args) => (
+  <ActionSheet {...args}>
+    <ActionSheet.Item>Action 1</ActionSheet.Item>
+    <ActionSheet.Item>Action 2</ActionSheet.Item>
+    <ActionSheet.Item>Action 3</ActionSheet.Item>
+  </ActionSheet>
+);
+Default.args = {
+  isOpen: true,
 };

--- a/components/ui/ActionSheet/ActionSheet.styles.tsx
+++ b/components/ui/ActionSheet/ActionSheet.styles.tsx
@@ -14,18 +14,15 @@ export const Wrapper = styled.div<{ isOpen: boolean }>`
   gap: 12px;
 
   animation: ${(props) => (props.isOpen ? "slideup" : "slidedown")} 250ms forwards;
-
-  & > div {
-    background-color: ${colors.overlay};
-    border-radius: 6px;
-    box-shadow: 0px 2px 80px rgba(0, 0, 0, 0.5);
-  }
 `;
 
-export const ActionList = styled.ul`
+export const ActionList = styled.div`
   display: flex;
   flex-direction: column;
   text-align: center;
+  background-color: ${colors.overlay};
+  border-radius: 6px;
+  box-shadow: 0px 2px 80px rgba(0, 0, 0, 0.5);
 
   & > button {
     border-top: 0.4px solid ${colors.gray900};
@@ -37,6 +34,9 @@ export const ActionList = styled.ul`
 `;
 
 export const ActionItem = styled.button`
+  background-color: ${colors.overlay};
+  border-radius: 6px;
+  box-shadow: 0px 2px 80px rgba(0, 0, 0, 0.5);
   width: 100%;
   padding: 20px;
   color: ${colors.gray400};

--- a/components/ui/ActionSheet/ActionSheet.styles.tsx
+++ b/components/ui/ActionSheet/ActionSheet.styles.tsx
@@ -4,7 +4,6 @@ import { Normal18CSS, Bold18CSS } from "../Typographies";
 
 export const Wrapper = styled.div<{ isOpen: boolean }>`
   position: fixed;
-  bottom: 0;
   left: 18px;
   right: 18px;
   bottom: 53px;

--- a/components/ui/ActionSheet/ActionSheet.tsx
+++ b/components/ui/ActionSheet/ActionSheet.tsx
@@ -1,3 +1,4 @@
+import { PropsWithChildren } from "react";
 import Animated from "@/components/ui/Animated/Animated";
 import Dimmed from "@/components/ui/Dimmed/Dimmed";
 import Portal from "@/components/ui/Portal/Portal";
@@ -5,35 +6,31 @@ import * as S from "./ActionSheet.styles";
 
 type Props = {
   isOpen: boolean;
-  actionList: Array<{
-    actionName: string;
-    onActionClick: (e: React.MouseEvent) => void;
-  }>;
   onClose: () => void;
 };
 
-const ActionSheet = ({ isOpen, actionList, onClose }: Props) => {
+const ActionSheet = ({ isOpen, onClose, children }: PropsWithChildren<Props>) => {
   return (
     <Portal>
       <Animated isOpen={isOpen}>
         <Dimmed onClick={onClose} />
         <S.Wrapper isOpen={isOpen}>
-          <div>
-            <S.ActionList>
-              {actionList.map(({ actionName, onActionClick }) => (
-                <S.ActionItem key={actionName} onClick={onActionClick}>
-                  {actionName}
-                </S.ActionItem>
-              ))}
-            </S.ActionList>
-          </div>
-          <div>
-            <S.CloseButton onClick={onClose}>닫기</S.CloseButton>
-          </div>
+          <S.ActionList>{children}</S.ActionList>
+          <S.CloseButton onClick={onClose}>닫기</S.CloseButton>
         </S.Wrapper>
       </Animated>
     </Portal>
   );
 };
+
+type ActionItemProps = {
+  onClick?: () => void;
+};
+
+const ActionItem = ({ onClick, children }: PropsWithChildren<ActionItemProps>) => {
+  return <S.ActionItem onClick={onClick}>{children}</S.ActionItem>;
+};
+
+ActionSheet.Item = ActionItem;
 
 export default ActionSheet;


### PR DESCRIPTION
## 관련 이슈

#issue

## 작업 내용⚒️
- ActionSheet 컴포넌트 설계 변경
  - 기존 방식: 액션 목록을 props로 전달
  - 변경 방식: 서브 컴포넌트로 분리된 액션 아이템을 사용처에서 합성해서 사용
- ArtworkCardList 컴포넌트에서 액션시트 로직 구분을 위해 ArtworkEditActionSheet 컴포넌트로 분리

## 논의 사항👥

