### PR TITLE
unmount 애니메이션을 위한 prop 전달 위치 수정

### DIFF
--- a/app/exhibition/[exhibitionId]/[artworkId]/page.styles.tsx
+++ b/app/exhibition/[exhibitionId]/[artworkId]/page.styles.tsx
@@ -71,7 +71,7 @@ export const ThumbnailItem = styled.li<{ isActive: boolean }>`
   border-radius: 2px;
 `;
 
-export const BottomSheetWrapper = styled.div<{ isOpen: boolean }>`
+export const BottomSheetWrapper = styled.div<{ isOpen?: boolean }>`
   position: fixed;
   left: 0;
   right: 0;

--- a/app/exhibition/[exhibitionId]/[artworkId]/page.tsx
+++ b/app/exhibition/[exhibitionId]/[artworkId]/page.tsx
@@ -10,7 +10,7 @@ import Tag from "@/components/ui/Tag/Tag/Tag";
 import EditBottomSheet from "@/components/pages/EditBottomSheet/EditBottomSheet/EditBottomSheet";
 import Dimmed from "@/components/ui/Dimmed/Dimmed";
 import Portal from "@/components/ui/Portal/Portal";
-import Animated from "@/components/ui/Animated/Animated";
+import { AnimatePresence } from "@/components/ui/AnimatePresence/AnimatePresence";
 import { FormData } from "@/components/pages/EditBottomSheet/EditBottomSheet/EditBottomSheet";
 import { useGetArtworkInfo, useGetArtworkList, useUpdateArtworkInfo } from "@/hooks/artwork";
 import useOverlay from "@/hooks/useOverlay";
@@ -117,11 +117,11 @@ export default function Page({
       </S.ThumbnailList>
       <Portal>
         {isOpenBottomSheet && <Dimmed onClick={closeBottomSheet} />}
-        <Animated isOpen={isOpenBottomSheet}>
+        <AnimatePresence isOpen={isOpenBottomSheet}>
           <S.BottomSheetWrapper>
             <EditBottomSheet defaultValues={artworkInfo} onSave={handleSave} />
           </S.BottomSheetWrapper>
-        </Animated>
+        </AnimatePresence>
       </Portal>
     </S.Wrapper>
   );

--- a/app/exhibition/[exhibitionId]/[artworkId]/page.tsx
+++ b/app/exhibition/[exhibitionId]/[artworkId]/page.tsx
@@ -118,7 +118,7 @@ export default function Page({
       <Portal>
         {isOpenBottomSheet && <Dimmed onClick={closeBottomSheet} />}
         <Animated isOpen={isOpenBottomSheet}>
-          <S.BottomSheetWrapper isOpen={isOpenBottomSheet}>
+          <S.BottomSheetWrapper>
             <EditBottomSheet defaultValues={artworkInfo} onSave={handleSave} />
           </S.BottomSheetWrapper>
         </Animated>

--- a/components/ui/ActionSheet/ActionSheet.styles.tsx
+++ b/components/ui/ActionSheet/ActionSheet.styles.tsx
@@ -34,17 +34,16 @@ export const ActionList = styled.div`
 `;
 
 export const ActionItem = styled.button`
-  background-color: ${colors.overlay};
   border-radius: 6px;
-  box-shadow: 0px 2px 80px rgba(0, 0, 0, 0.5);
   width: 100%;
-  padding: 20px;
+  padding: 20px 0;
   color: ${colors.gray400};
   ${Normal18CSS};
   letter-spacing: -0.3px;
 `;
 
 export const CloseButton = styled(ActionItem)`
+  box-shadow: 0px 2px 80px rgba(0, 0, 0, 0.5);
   ${Bold18CSS};
   color: white;
 `;

--- a/components/ui/ActionSheet/ActionSheet.styles.tsx
+++ b/components/ui/ActionSheet/ActionSheet.styles.tsx
@@ -1,8 +1,9 @@
 import styled from "styled-components";
 import { colors } from "@/styles/colors";
 import { Normal18CSS, Bold18CSS } from "../Typographies";
+import "@/styles/keyframes.css";
 
-export const Wrapper = styled.div<{ isOpen: boolean }>`
+export const Wrapper = styled.div<{ isOpen?: boolean }>`
   position: fixed;
   left: 18px;
   right: 18px;

--- a/components/ui/ActionSheet/ActionSheet.tsx
+++ b/components/ui/ActionSheet/ActionSheet.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from "react";
-import Animated from "@/components/ui/Animated/Animated";
+import { AnimatePresence } from "@/components/ui/AnimatePresence/AnimatePresence";
 import Dimmed from "@/components/ui/Dimmed/Dimmed";
 import Portal from "@/components/ui/Portal/Portal";
 import * as S from "./ActionSheet.styles";
@@ -13,12 +13,12 @@ const ActionSheet = ({ isOpen, onClose, children }: PropsWithChildren<Props>) =>
   return (
     <Portal>
       {isOpen && <Dimmed onClick={onClose} />}
-      <Animated isOpen={isOpen}>
+      <AnimatePresence isOpen={isOpen}>
         <S.Wrapper>
           <S.ActionList>{children}</S.ActionList>
           <S.CloseButton onClick={onClose}>닫기</S.CloseButton>
         </S.Wrapper>
-      </Animated>
+      </AnimatePresence>
     </Portal>
   );
 };

--- a/components/ui/ActionSheet/ActionSheet.tsx
+++ b/components/ui/ActionSheet/ActionSheet.tsx
@@ -12,9 +12,9 @@ type Props = {
 const ActionSheet = ({ isOpen, onClose, children }: PropsWithChildren<Props>) => {
   return (
     <Portal>
+      {isOpen && <Dimmed onClick={onClose} />}
       <Animated isOpen={isOpen}>
-        <Dimmed onClick={onClose} />
-        <S.Wrapper isOpen={isOpen}>
+        <S.Wrapper>
           <S.ActionList>{children}</S.ActionList>
           <S.CloseButton onClick={onClose}>닫기</S.CloseButton>
         </S.Wrapper>

--- a/components/ui/AnimatePresence/AnimatePresence.tsx
+++ b/components/ui/AnimatePresence/AnimatePresence.tsx
@@ -6,7 +6,7 @@ type Props = {
   children: ReactElement;
 };
 
-const Animated = ({ isOpen, children }: Props) => {
+export const AnimatePresence = ({ isOpen, children }: Props) => {
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
@@ -24,5 +24,3 @@ const Animated = ({ isOpen, children }: Props) => {
       })
     : null;
 };
-
-export default Animated;

--- a/components/ui/Animated/Animated.tsx
+++ b/components/ui/Animated/Animated.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import { ReactElement, useEffect, useState, cloneElement } from "react";
+import "@/styles/keyframes.css";
 
 type Props = {
   isOpen: boolean;
-  children: React.ReactNode;
+  children: ReactElement;
 };
 
 const Animated = ({ isOpen, children }: Props) => {
@@ -16,7 +17,12 @@ const Animated = ({ isOpen, children }: Props) => {
     if (!isOpen) setIsVisible(false);
   };
 
-  return isVisible ? <div onAnimationEnd={handleAnimationEnd}>{children}</div> : null;
+  return isVisible
+    ? cloneElement(children, {
+        isOpen,
+        onAnimationEnd: handleAnimationEnd,
+      })
+    : null;
 };
 
 export default Animated;

--- a/styles/globals.tsx
+++ b/styles/globals.tsx
@@ -49,26 +49,4 @@ ul {
   list-style: none;
 }
 
-@keyframes slideup {
-  from {
-    transform: translateY(20%);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
-
-@keyframes slidedown {
-  from {
-    transform: translateY(0);
-    opacity: 1;
-  }
-  to {
-    transform: translateY(20%);
-    opacity: 0;
-  }
-}
-
 `;

--- a/styles/keyframes.css
+++ b/styles/keyframes.css
@@ -1,0 +1,21 @@
+@keyframes slideup {
+  from {
+    transform: translateY(20%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slidedown {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(20%);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## 관련 이슈

#issue

## 작업 내용⚒️
- keyframes css로 분리
- AnimatePresence 컴포넌트에서 하위 컴포넌트로 isOpen 변수와 AnimationEnd 이벤트 핸들러 주입
  -  AnimationEnd 이벤트 핸들러 바인딩을 위해 존재했던 불필요한 div 제거됨
  - isOpen prop을 상위, 하위 컴포넌트 모두에 전달해야 했던 상황 개선

## 논의 사항👥

