### PR TITLE
핀 버튼 클릭시 navigate 액션이 호출되는 오류 수정

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -35,12 +35,11 @@ function Page() {
 
   const isEmpty = allPostInfo.length === 0;
 
-  const handleTogglePin = async (e: React.MouseEvent, item: PostDetailInfo) => {
+  const handleTogglePin = (e: React.MouseEvent, item: PostDetailInfo) => {
     mutate({ id: item.id, category: categoryId || undefined, pinned: !(item.id === fixedExhibition?.id) });
   };
 
-  const handleClickItem = useCallback(async (e: React.MouseEvent, item: PostDetailInfo) => {
-    e.preventDefault();
+  const handleClickItem = useCallback((e: React.MouseEvent, item: PostDetailInfo) => {
     sendMessage(["NAVIGATE_TO_EXHIBITION_DETAIL", item]);
   }, []);
 

--- a/components/pages/Home/ExhibitionCardList/ExhibitionCardList.tsx
+++ b/components/pages/Home/ExhibitionCardList/ExhibitionCardList.tsx
@@ -17,6 +17,7 @@ export const ExhibitionCardList = (props: Props) => {
   const handleTogglePin = useCallback(
     (item: PostDetailInfo) => {
       return (e: React.MouseEvent) => {
+        e.stopPropagation();
         onTogglePin?.(e, item);
       };
     },


### PR DESCRIPTION
## 관련 이슈

#issue

## 작업 내용⚒️
- 이벤트 버블링으로 인해 전시 카드의 클릭 이벤트가 호출됨
- 핀 버튼 핸들러에 stopPropagation 적용하여 이벤트 버블링을 중단시킴

## 논의 사항👥

