### PR TITLE
refactor: 홈->캘린더 페이지 라우팅 방식 변경

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -49,7 +49,7 @@ function Page() {
   });
 
   const handleGoBackClick = useCallback(() => {
-    sendMessage(["GO_BACK"]);
+    router.back();
   }, []);
 
   const handleYearMonth = useCallback(

--- a/app/home/components/AppBar/AppBar.styles.tsx
+++ b/app/home/components/AppBar/AppBar.styles.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { colors } from "@/styles/colors";
+import Link from "next/link";
 
 export const Wrapper = styled.div`
   display: flex;
@@ -21,4 +22,8 @@ export const MenuGroup = styled.div`
   flex-direction: row;
   align-items: center;
   gap: 12px;
+`;
+
+export const IconLink = styled(Link)`
+  display: flex;
 `;

--- a/app/home/components/AppBar/AppBar.tsx
+++ b/app/home/components/AppBar/AppBar.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback } from "react";
 import * as S from "./AppBar.styles";
+import Icon from "@/components/Icon/Icon/Icon";
 import { IconButton } from "@/components/Button/IconButton/IconButton";
 import { sendMessage } from "@/libs/message/message";
 
@@ -11,10 +12,6 @@ interface Props {
 
 export const AppBar = (props: Props) => {
   const { className } = props;
-
-  const handleCalendar = useCallback(() => {
-    sendMessage(["NAVIGATE_TO_CALENDAR"]);
-  }, []);
 
   const handleMy = useCallback(() => {
     sendMessage(["NAVIGATE_TO_MY", { userId: "1" }]);
@@ -30,12 +27,9 @@ export const AppBar = (props: Props) => {
         />
       </S.LogoGroup>
       <S.MenuGroup>
-        <IconButton
-          iconProps={{
-            name: "CalendarIcon",
-          }}
-          onClick={handleCalendar}
-        />
+        <S.IconLink href="/calendar">
+          <Icon name="CalendarIcon" />
+        </S.IconLink>
         <IconButton
           iconProps={{
             name: "UserIcon",


### PR DESCRIPTION
## 관련 이슈

#issue

## 작업 내용⚒️
- postMessage를 거치지 않고 웹뷰 내에서 라우팅
- 페이지 전환 속도를 향상시키기 위함

## 논의 사항👥

