### PR TITLE
fix: message payload 필드명 수정

### DIFF
--- a/app/calendar/components/ExhibitSelectModal/ExhibitSelectModal.tsx
+++ b/app/calendar/components/ExhibitSelectModal/ExhibitSelectModal.tsx
@@ -13,9 +13,9 @@ type Props = {
 export const ExhibitSelectModal = ({ selectedDate, onClose }: Props) => {
   const { data: exhibitsByDate } = useGetExhibitsByDate(selectedDate);
 
-  const handleSelectExhibit = (exhibitId: number) => {
+  const handleSelectExhibit = (id: number) => {
     return (e: React.MouseEvent) => {
-      sendMessage(["NAVIGATE_TO_EXHIBITION_DETAIL", { exhibitId }]);
+      sendMessage(["NAVIGATE_TO_EXHIBITION_DETAIL", { id }]);
     };
   };
 

--- a/libs/message/message.ts
+++ b/libs/message/message.ts
@@ -12,7 +12,7 @@ export type Actions = {
   };
   NAVIGATE_TO_EDIT: {};
   NAVIGATE_TO_EXHIBITION_DETAIL: {
-    payload: PostDetailInfo | { exhibitId: number };
+    payload: PostDetailInfo | { id: number };
   };
   EDIT_BOTTOM_SHEET_SAVE: {
     payload: {


### PR DESCRIPTION
## 관련 이슈

#issue

## 작업 내용⚒️
- 홈/캘린더 페이지가 하나의 액티비티로 관리되게 변경되었으므로 payload 필드명을 통일한다

## 논의 사항👥

