### PR TITLE
전시 정보 페이지 NavigationBar 컴포넌트 분리 및 스타일 조정

### DIFF
--- a/app/exhibition/[exhibitionId]/components/ExhibitInformationHeader/ExhibitInformationHeader.styles.tsx
+++ b/app/exhibition/[exhibitionId]/components/ExhibitInformationHeader/ExhibitInformationHeader.styles.tsx
@@ -8,6 +8,7 @@ export const Header = styled.header`
 
 export const GradientOverlay = styled.div`
   position: relative;
+  padding-top: 100px;
   background: linear-gradient(180deg, rgba(0, 0, 0, 0.4) 0%, #161616 97.31%);
 `;
 
@@ -15,7 +16,7 @@ export const Content = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
+  padding: 14px 20px;
 `;
 
 export const ArtworkAddButton = styled.button`

--- a/app/exhibition/[exhibitionId]/components/ExhibitInformationHeader/ExhibitInformationHeader.tsx
+++ b/app/exhibition/[exhibitionId]/components/ExhibitInformationHeader/ExhibitInformationHeader.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import Image from "next/image";
-import NavigationBar from "@/components/NavigationBar/NavigationBar";
 import Icon from "@/components/Icon/Icon/Icon";
 import ImageUploadSelectModal from "../ImageUploadSelectModal/ImageUploadSelectModal";
 import { colors } from "@/styles/colors";
 import useOverlay from "@/hooks/useOverlay";
-import { sendMessage } from "@/libs/message/message";
 import { useGetPostInfo } from "@/hooks/exhibition";
 import * as S from "./ExhibitInformationHeader.styles";
 
@@ -19,15 +17,6 @@ export const ExhibitInformationHeader = ({ exhibitionId }: Props) => {
   const { mainImage, categoryName, name, postDate } = { ...postInfo };
   const { isOpen: isOpenModal, open, close } = useOverlay();
 
-  const handleGoBackClick = () => {
-    sendMessage(["GO_BACK"]);
-  };
-
-  const handleEditClick = () => {
-    if (!postInfo) return;
-    sendMessage(["NAVIGATE_TO_EXHIBIT_EDIT", postInfo]);
-  };
-
   const handleArtworkAdd = () => {
     open();
   };
@@ -38,7 +27,6 @@ export const ExhibitInformationHeader = ({ exhibitionId }: Props) => {
       <S.Header>
         {mainImage && <Image alt="대표 사진" src={mainImage} fill style={{ objectFit: "cover" }} priority />}
         <S.GradientOverlay>
-          <NavigationBar onGoBackClick={handleGoBackClick} onEditClick={handleEditClick} />
           <S.Content>
             <S.ExhibitionInfo>
               <S.Category>{categoryName}</S.Category>

--- a/app/exhibition/[exhibitionId]/components/NavigationBar/NavigationBar.styles.tsx
+++ b/app/exhibition/[exhibitionId]/components/NavigationBar/NavigationBar.styles.tsx
@@ -1,0 +1,9 @@
+import NavigationBar from "@/components/NavigationBar/NavigationBar";
+import styled from "styled-components";
+
+export const NavigationBarStyled = styled(NavigationBar)`
+  position: absolute;
+  width: 100%;
+  padding-top: 50px;
+  z-index: 100;
+`;

--- a/app/exhibition/[exhibitionId]/components/NavigationBar/NavigationBar.tsx
+++ b/app/exhibition/[exhibitionId]/components/NavigationBar/NavigationBar.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { sendMessage } from "@/libs/message/message";
+import { PostDetailInfo } from "@/__generate__/post";
+import * as S from "./NavigationBar.styles";
+
+type Props = {
+  exhibitionId: number;
+};
+
+export const NavigationBar = ({ exhibitionId }: Props) => {
+  const handleGoBackClick = () => {
+    sendMessage(["GO_BACK"]);
+  };
+
+  const queryClient = useQueryClient();
+  const handleEditClick = () => {
+    const postInfo = queryClient.getQueryData<PostDetailInfo>(["postInfo", exhibitionId]);
+    if (!postInfo) return;
+    sendMessage(["NAVIGATE_TO_EXHIBIT_EDIT", postInfo]);
+  };
+
+  return <S.NavigationBarStyled onGoBackClick={handleGoBackClick} onEditClick={handleEditClick} />;
+};

--- a/app/exhibition/[exhibitionId]/page.tsx
+++ b/app/exhibition/[exhibitionId]/page.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary } from "@/components/ErrorBoundary/ErrorBoundary";
 import { ExhibitInformationHeader } from "./components/ExhibitInformationHeader/ExhibitInformationHeader";
 import { LinkPreviewCard, LinkPreviewCardError, LinkPreviewCardSkeleton } from "./components/LinkPreviewCard";
 import { ArtworkCardList, ArtworkCounter } from "./components/ArtworkCardList/ArtworkCardList.server";
+import { NavigationBar } from "./components/NavigationBar/NavigationBar";
 import { useFetchPostInfo } from "@/hooks/exhibition.server";
 import { getDehydratedState } from "@/libs/react-query-ssr/getDehydratedState";
 import styles from "./page.module.css";
@@ -15,6 +16,7 @@ export default async function Page({ params }: { params: { exhibitionId: string 
 
   return (
     <Hydrate state={dehydratedState}>
+      <NavigationBar exhibitionId={exhibitionId} />
       <ExhibitInformationHeader exhibitionId={exhibitionId} />
       <div className={styles.content}>
         <Suspense>

--- a/components/NavigationBar/NavigationBar.styles.tsx
+++ b/components/NavigationBar/NavigationBar.styles.tsx
@@ -1,13 +1,13 @@
 import styled from "styled-components";
 import { Normal16CSS, Bold18CSS } from "@/components/Typographies";
 import { colors } from "@/styles/colors";
+import { IconButton } from "@/components/Button/IconButton/IconButton";
 
 export const Wrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
   background-color: transparent;
-  padding-top: 50px;
 `;
 
 export const Title = styled.span`
@@ -15,8 +15,12 @@ export const Title = styled.span`
   ${Bold18CSS}
 `;
 
+export const GoBackButton = styled(IconButton)`
+  padding: 13px 16px;
+`;
+
 export const Button = styled.button`
-  padding: 20px;
+  padding: 15px 20px;
   color: ${colors.gray400};
   ${Normal16CSS}
 `;

--- a/components/NavigationBar/NavigationBar.tsx
+++ b/components/NavigationBar/NavigationBar.tsx
@@ -1,4 +1,4 @@
-import Icon, { IconType } from "@/components/Icon/Icon/Icon";
+import { IconType } from "@/components/Icon/Icon/Icon";
 import * as S from "./NavigationBar.styles";
 
 export interface Props {
@@ -21,9 +21,7 @@ const NavigationBar = ({
 }: Props) => {
   return (
     <S.Wrapper className={className}>
-      <S.Button onClick={onGoBackClick}>
-        <Icon name={goBack.name} size={goBack.size} />
-      </S.Button>
+      <S.GoBackButton iconProps={{ name: goBack.name, size: goBack.size }} onClick={onGoBackClick} />
       <S.Title>{current}</S.Title>
       {onEditClick && <S.Button onClick={onEditClick}>편집</S.Button>}
     </S.Wrapper>


### PR DESCRIPTION
## 관련 이슈

#issue

## 작업 내용⚒️
- 편집 버튼 클릭시 query cache에서 전시 정보 데이터 pull
- padding 값 조정

## 논의 사항👥

