### PR TITLE
웹뷰 refocus시 쿼리 업데이트 수행

### DIFF
--- a/app/home/components/AppBar/AppBar.tsx
+++ b/app/home/components/AppBar/AppBar.tsx
@@ -14,7 +14,7 @@ export const AppBar = (props: Props) => {
   const { className } = props;
 
   const handleMy = useCallback(() => {
-    sendMessage(["NAVIGATE_TO_MY", { userId: "1" }]);
+    sendMessage(["NAVIGATE_TO_MY"]);
   }, []);
 
   return (

--- a/hooks/useVisibilityChange.ts
+++ b/hooks/useVisibilityChange.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+
+type Props = {
+  onVisible?: VoidFunction;
+  onHidden?: VoidFunction;
+};
+
+export const useVisibilityChange = ({ onVisible, onHidden }: Props) => {
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        onVisible?.();
+      } else onHidden?.();
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
+};

--- a/libs/message/message.ts
+++ b/libs/message/message.ts
@@ -5,11 +5,7 @@ export type Actions = {
   NAVIGATE_TO_HOME: {};
   NAVIGATE_TO_BELL: {};
   NAVIGATE_TO_CALENDAR: {};
-  NAVIGATE_TO_MY: {
-    payload: {
-      userId: string;
-    };
-  };
+  NAVIGATE_TO_MY: {};
   NAVIGATE_TO_EDIT: {};
   NAVIGATE_TO_EXHIBITION_DETAIL: {
     payload: PostDetailInfo | { id: number };

--- a/libs/react-query.tsx
+++ b/libs/react-query.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useVisibilityChange } from "@/hooks/useVisibilityChange";
 
 export default function QueryClientWrapper({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -10,11 +11,18 @@ export default function QueryClientWrapper({ children }: { children: React.React
         defaultOptions: {
           queries: {
             retry: 0,
+            refetchOnWindowFocus: false,
             staleTime: 20 * 1000,
           },
         },
       })
   );
+
+  const invalidateAllQueries = () => {
+    queryClient.invalidateQueries();
+  };
+
+  useVisibilityChange({ onVisible: invalidateAllQueries });
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }


### PR DESCRIPTION
## 관련 이슈

## 작업 내용⚒️

- 새 액티비티에서 데이터 수정 후 웹뷰로 돌아오는 경우 데이터 최신화가 필요하다.
- refetchOnWindowFocus 옵션은 staleTime이전에 focus될 경우 리페칭을 수행하지 않기 때문에 데이터 최신화 문제를 완전히 해결할 수 없다.
- 웹뷰가 refocus 되었을 때 데이터 최신화를 위해 visibilityState 변경을 감지하여 스크린의 모든 쿼리를 무효화한다.

## 논의 사항👥

