### PR TITLE
queryClient hydrate 제거 및 렌더링 이후에 open graph 파싱하도록 수정

### DIFF
--- a/app/exhibition/[exhibitionId]/components/LinkPreviewCard/LinkPreviewCard.server.tsx
+++ b/app/exhibition/[exhibitionId]/components/LinkPreviewCard/LinkPreviewCard.server.tsx
@@ -1,19 +1,12 @@
 import { useFetchIndexHtmlByLink } from "@/hooks/exhibition.server";
 import { LinkPreviewCard as LinkPreviewCardClient } from "./LinkPreviewCard";
-import { getDehydratedState } from "@/libs/react-query-ssr/getDehydratedState";
-import { Hydrate } from "@tanstack/react-query";
 
 type Props = {
   link: string;
 };
 
 export const LinkPreviewCard = async ({ link }: Props) => {
-  await useFetchIndexHtmlByLink(link);
-  const dehydratedState = getDehydratedState();
+  const html = await useFetchIndexHtmlByLink(link);
 
-  return (
-    <Hydrate state={dehydratedState}>
-      <LinkPreviewCardClient link={link} />
-    </Hydrate>
-  );
+  return <LinkPreviewCardClient link={link} html={html} />;
 };

--- a/app/exhibition/[exhibitionId]/components/LinkPreviewCard/LinkPreviewCard.stories.tsx
+++ b/app/exhibition/[exhibitionId]/components/LinkPreviewCard/LinkPreviewCard.stories.tsx
@@ -9,7 +9,12 @@ export default {
   component: LinkPreviewCard,
 } as Meta;
 
-export const Default = () => <LinkPreviewCard link="artie.com" />;
+export const Default = () => (
+  <LinkPreviewCard
+    link="artie.com"
+    html='<html><head><meta property="og:image" content="https://picsum.photos/900" /><meta property="og:title" content="Example Website" /><meta property="og:description" content="" /></head></html>'
+  />
+);
 
 export const NoImage = () => (
   <S.Wrapper>

--- a/app/exhibition/[exhibitionId]/components/LinkPreviewCard/LinkPreviewCard.tsx
+++ b/app/exhibition/[exhibitionId]/components/LinkPreviewCard/LinkPreviewCard.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import { IconButton } from "@/components/Button/IconButton/IconButton";
+import { LinkPreviewCardSkeleton } from "./LinkPreviewCard.skeleton";
 import { sendMessage } from "@/libs/message/message";
 import { extractOpenGraph } from "@/utils/extractOpenGraph";
+import { OgData } from "@/utils/extractOpenGraph";
 import * as S from "./LinkPreviewCard.styles";
 
 type Props = {
@@ -13,11 +15,18 @@ type Props = {
 };
 
 export const LinkPreviewCard = ({ link, html }: Props) => {
-  const { title, image } = useMemo(() => extractOpenGraph(html), [html]);
+  const [ogData, setOgData] = useState<OgData>();
+  const { title, image } = ogData ?? {};
+
+  useEffect(() => {
+    setOgData(extractOpenGraph(html));
+  }, [html]);
 
   const handleClickLink = () => {
     sendMessage(["OPEN_NEW_WINDOW", { url: link }]);
   };
+
+  if (!ogData) return <LinkPreviewCardSkeleton />;
 
   return (
     <S.Wrapper>

--- a/app/exhibition/[exhibitionId]/components/LinkPreviewCard/LinkPreviewCard.tsx
+++ b/app/exhibition/[exhibitionId]/components/LinkPreviewCard/LinkPreviewCard.tsx
@@ -5,15 +5,14 @@ import Image from "next/image";
 import { IconButton } from "@/components/Button/IconButton/IconButton";
 import { sendMessage } from "@/libs/message/message";
 import { extractOpenGraph } from "@/utils/extractOpenGraph";
-import { useGetIndexHtmlByLink } from "@/hooks/exhibition";
 import * as S from "./LinkPreviewCard.styles";
 
 type Props = {
   link: string;
+  html: string;
 };
 
-export const LinkPreviewCard = ({ link }: Props) => {
-  const { data: html } = useGetIndexHtmlByLink(link);
+export const LinkPreviewCard = ({ link, html }: Props) => {
   const { title, image } = useMemo(() => extractOpenGraph(html), [html]);
 
   const handleClickLink = () => {

--- a/app/exhibition/[exhibitionId]/page.stories.tsx
+++ b/app/exhibition/[exhibitionId]/page.stories.tsx
@@ -21,7 +21,10 @@ export const Template = () => (
     <div className={styles.content}>
       <ArtworkCount exhibitionId={3} />
       <div className={styles.preview}>
-        <LinkPreviewCard link="artie.com" />
+        <LinkPreviewCard
+          link="artie.com"
+          html='<html><head><meta property="og:image" content="https://picsum.photos/900" /><meta property="og:title" content="Example Website" /><meta property="og:description" content="" /></head></html>'
+        />
       </div>
       <ArtworkCardList exhibitionId={3} />
     </div>

--- a/hooks/exhibition.tsx
+++ b/hooks/exhibition.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
-import { getAllPostPage, getIndexHtmlByLink, getPostInfoWithCategory, togglePinById } from "@/apis/exhibition";
+import { getAllPostPage, getPostInfoWithCategory, togglePinById } from "@/apis/exhibition";
 
 export const useGetExhibitionList = (direction: "ASC" | "DESC", category?: number) => {
   const { data, fetchNextPage } = useInfiniteQuery({
@@ -27,13 +27,5 @@ export const useTogglePinById = (direction: "ASC" | "DESC") => {
     onSuccess: (_, { category }) => {
       queryClient.invalidateQueries(["getAllPostPage", { direction, category }]);
     },
-  });
-};
-
-export const useGetIndexHtmlByLink = (link: string) => {
-  return useQuery({
-    queryKey: ["indexHtmlByLink", link],
-    queryFn: () => getIndexHtmlByLink(link),
-    staleTime: Infinity,
   });
 };

--- a/utils/extractOpenGraph.ts
+++ b/utils/extractOpenGraph.ts
@@ -1,10 +1,12 @@
+export type OgData = {
+  [key: string]: string | undefined;
+};
+
 export const extractOpenGraph = (html: string = "") => {
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, "text/html");
 
-  const ogData: {
-    [key: string]: string | undefined;
-  } = {};
+  const ogData: OgData = {};
 
   const metaTags = doc.querySelectorAll('meta[property^="og:"]');
   metaTags.forEach((tag: Element) => {


### PR DESCRIPTION
## 관련 이슈

#issue

## 작업 내용⚒️
- 링크 미리보기 요청이 client-side에서 일어나지 않도록 queryClient hydrate 제거
- DOMParser API를 사용하는 extractOpenGraph 유틸 함수가 렌더링 이후에 사용되도록 수정

## 논의 사항👥

